### PR TITLE
release: v1.8.1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -3,6 +3,14 @@ Flask-Security-Fork Changelog
 
 Here you can see the full list of changes between each Flask-Security-Fork release.
 
+Version 1.8.1
+-------------
+
+Released November 15th 2016
+
+- Fixed a security bug when validating a confirmation token, also checks
+  if the email that the token was created with matches the user's current email.
+
 Version 1.8.0
 -------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,7 +49,7 @@ copyright = u'2012, Matt Wright'
 # built documents.
 #
 # The short X.Y version.
-version = '1.8.0'
+version = '1.8.1'
 # The full version, including alpha/beta/rc tags.
 release = version
 

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -20,4 +20,4 @@ from .signals import confirm_instructions_sent, password_reset, \
     reset_password_instructions_sent, user_confirmed, user_registered
 from .utils import login_user, logout_user, url_for_security
 
-__version__ = '1.8.0'
+__version__ = '1.8.1'

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class PyTest(TestCommand):
 
 setup(
     name='Flask-Security-Fork',
-    version='1.8.0',
+    version='1.8.1',
     url='https://github.com/inveniosoftware/flask-security-fork',
     license='MIT',
     author='Matt Wright',


### PR DESCRIPTION
Signed-off-by: Jiri Kuncar <jiri.kuncar@cern.ch>