### PR TITLE
global: encrypt_password -> hash_password

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -71,6 +71,8 @@ Utils
 
 .. autofunction:: flask_security.utils.encrypt_password
 
+.. autofunction:: flask_security.utils.hash_password
+
 .. autofunction:: flask_security.utils.url_for_security
 
 .. autofunction:: flask_security.utils.get_within_delta

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -28,11 +28,11 @@ Core
                                          messages during security procedures.
                                          Defaults to ``True``.
 ``SECURITY_PASSWORD_HASH``               Specifies the password hash algorithm to
-                                         use when encrypting and decrypting
-                                         passwords. Recommended values for
-                                         production systems are ``bcrypt``,
-                                         ``sha512_crypt``, or ``pbkdf2_sha512``.
-                                         Defaults to ``plaintext``.
+                                         use when hashing passwords. Recommended
+                                         values for production systems are
+                                         ``bcrypt``, ``sha512_crypt``, or
+                                         ``pbkdf2_sha512``. Defaults to
+                                         ``plaintext``.
 ``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. This is only
                                          used if the password hash type is set
                                          to something other than plain text.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -27,12 +27,12 @@ and all roles should be uniquely named. This feature is implemented using the
 control, you can refer to the Flask-Principal `documentation on this topic`_.
 
 
-Password Encryption
--------------------
+Password Hashing
+----------------
 
-Password encryption is enabled with `passlib`_. Passwords are stored in plain
-text by default but you can easily configure the encryption algorithm. You
-should **always use an encryption algorithm** in your production environment.
+Password hashing is enabled with `passlib`_. Passwords are stored in plain
+text by default but you can easily configure the hashing algorithm. You
+should **always use an hashing algorithm** in your production environment.
 You may also specify to use HMAC with a configured salt value in addition to the
 algorithm chosen. Bear in mind passlib does not assume which algorithm you will
 choose and may require additional libraries to be installed.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Flask application. They include:
 
 1. Session based authentication
 2. Role management
-3. Password encryption
+3. Password hashing
 4. Basic HTTP authentication
 5. Token based authentication
 6. Token based account activation (optional)

--- a/flask_security/changeable.py
+++ b/flask_security/changeable.py
@@ -14,7 +14,7 @@ from flask import current_app as app
 from werkzeug.local import LocalProxy
 
 from .signals import password_changed
-from .utils import config_value, encrypt_password, send_mail
+from .utils import config_value, hash_password, send_mail
 
 # Convenient references
 _security = LocalProxy(lambda: app.extensions['security'])
@@ -36,9 +36,9 @@ def change_user_password(user, password):
     """Change the specified user's password
 
     :param user: The user to change_password
-    :param password: The unencrypted new password
+    :param password: The unhashed new password
     """
-    user.password = encrypt_password(password)
+    user.password = hash_password(password)
     _datastore.put(user)
     send_password_changed_notice(user)
     password_changed.send(app._get_current_object(),

--- a/flask_security/cli.py
+++ b/flask_security/cli.py
@@ -18,7 +18,7 @@ from flask import current_app
 from werkzeug.datastructures import MultiDict
 from werkzeug.local import LocalProxy
 
-from .utils import encrypt_password
+from .utils import hash_password
 
 try:
     from flask.cli import with_appcontext
@@ -64,7 +64,7 @@ def users_create(identity, password, active):
     )
 
     if form.validate():
-        kwargs['password'] = encrypt_password(kwargs['password'])
+        kwargs['password'] = hash_password(kwargs['password'])
         kwargs['active'] = active
         _datastore.create_user(**kwargs)
         click.secho('User created successfully.', fg='green')

--- a/flask_security/recoverable.py
+++ b/flask_security/recoverable.py
@@ -14,7 +14,7 @@ from werkzeug.local import LocalProxy
 from werkzeug.security import safe_str_cmp
 
 from .signals import password_reset, reset_password_instructions_sent
-from .utils import config_value, encrypt_password, get_token_status, md5, \
+from .utils import config_value, hash_password, get_token_status, md5, \
     send_mail, url_for_security
 
 # Convenient references
@@ -86,9 +86,9 @@ def update_password(user, password):
     """Update the specified user's password
 
     :param user: The user to update_password
-    :param password: The unencrypted new password
+    :param password: The unhashed new password
     """
-    user.password = encrypt_password(password)
+    user.password = hash_password(password)
     _datastore.put(user)
     send_password_reset_notice(user)
     password_reset.send(app._get_current_object(), user=user)

--- a/flask_security/registerable.py
+++ b/flask_security/registerable.py
@@ -14,7 +14,7 @@ from werkzeug.local import LocalProxy
 
 from .confirmable import generate_confirmation_link
 from .signals import user_registered
-from .utils import config_value, do_flash, encrypt_password, get_message, \
+from .utils import config_value, do_flash, hash_password, get_message, \
     send_mail
 
 # Convenient references
@@ -25,7 +25,7 @@ _datastore = LocalProxy(lambda: _security.datastore)
 
 def register_user(**kwargs):
     confirmation_link, token = None, None
-    kwargs['password'] = encrypt_password(kwargs['password'])
+    kwargs['password'] = hash_password(kwargs['password'])
     user = _datastore.create_user(**kwargs)
     _datastore.commit()
 

--- a/flask_security/script.py
+++ b/flask_security/script.py
@@ -17,7 +17,7 @@ from flask import current_app
 from flask_script import Command, Option
 from werkzeug.local import LocalProxy
 
-from .utils import encrypt_password
+from .utils import hash_password
 
 try:
     import simplejson as json
@@ -65,7 +65,7 @@ class CreateUserCommand(Command):
         form = ConfirmRegisterForm(MultiDict(kwargs), csrf_enabled=False)
 
         if form.validate():
-            kwargs['password'] = encrypt_password(kwargs['password'])
+            kwargs['password'] = hash_password(kwargs['password'])
             _datastore.create_user(**kwargs)
             print('User created successfully.')
             kwargs['password'] = '****'

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -13,6 +13,7 @@ import base64
 import hashlib
 import hmac
 import sys
+import warnings
 from contextlib import contextmanager
 from datetime import timedelta
 
@@ -148,7 +149,7 @@ def verify_and_update_password(password, user):
     verified, new_password = _pwd_context.verify_and_update(
         password, user.password)
     if verified and new_password:
-        user.password = encrypt_password(password)
+        user.password = hash_password(password)
         _datastore.put(user)
     return verified
 
@@ -158,12 +159,31 @@ def encrypt_password(password):
 
     It uses the configured encryption options.
 
+    .. deprecated:: 2.0.2
+       Use :func:`hash_password` instead.
+
     :param password: The plaintext password to encrypt
+    """
+    warnings.warn(
+        'Please use hash_password instead of encrypt_password.',
+        DeprecationWarning
+    )
+    return hash_password(password)
+
+
+def hash_password(password):
+    """Hash the specified plaintext password.
+
+    It uses the configured hashing options.
+
+    .. versionadded:: 2.0.2
+
+    :param password: The plaintext password to hash
     """
     if _security.password_hash == 'plaintext':
         return password
     signed = get_hmac(password).decode('ascii')
-    return _pwd_context.encrypt(signed)
+    return _pwd_context.hash(signed)
 
 
 def encode_string(string):

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ install_requires = [
     'Flask-Principal>=0.3.3',
     'Flask-WTF>=0.13.1',
     'itsdangerous>=0.21',
-    'passlib>=1.6.4',
+    'passlib>=1.7',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Deprecates the misnamed `encrypt_password` in favor of `hash_password`, mirroring a similar change in `Passlib`: https://pythonhosted.org/passlib/history/1.7.html#overview.