### PR TITLE
add SECURITY_SINGLE_HASH configuration parameter

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -37,6 +37,13 @@ Core
                                          used if the password hash type is set
                                          to something other than plain text.
                                          Defaults to ``None``.
+``SECURITY_PASSWORD_SINGLE_HASH``        Specifies that passwords should only be
+                                         hashed once. By default, passwords are
+                                         hashed twice, first with
+                                         ``SECURITY_PASSWORD_SALT``, and then
+                                         with a random salt. May be useful for
+                                         integrating with other applications.
+                                         Defaults to ``False``.
 ``SECURITY_HASHING_SCHEMES``             List of algorithms used for
                                          creating and validating tokens.
                                          Defaults to ``sha256_crypt``.

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -44,6 +44,7 @@ _default_config = {
     'FLASH_MESSAGES': True,
     'PASSWORD_HASH': 'plaintext',
     'PASSWORD_SALT': None,
+    'PASSWORD_SINGLE_HASH': False,
     'LOGIN_URL': '/login',
     'LOGOUT_URL': '/logout',
     'REGISTER_URL': '/register',

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -12,10 +12,21 @@ from utils import authenticate, init_app_with_options
 from flask_security.utils import encrypt_password, verify_password
 
 
-def test_verify_password_bcrypt(app, sqlalchemy_datastore):
+def test_verify_password_bcrypt_double_hash(app, sqlalchemy_datastore):
     init_app_with_options(app, sqlalchemy_datastore, **{
         'SECURITY_PASSWORD_HASH': 'bcrypt',
-        'SECURITY_PASSWORD_SALT': 'salty'
+        'SECURITY_PASSWORD_SALT': 'salty',
+        'SECURITY_PASSWORD_SINGLE_HASH': False,
+    })
+    with app.app_context():
+        assert verify_password('pass', encrypt_password('pass'))
+
+
+def test_verify_password_bcrypt_single_hash(app, sqlalchemy_datastore):
+    init_app_with_options(app, sqlalchemy_datastore, **{
+        'SECURITY_PASSWORD_HASH': 'bcrypt',
+        'SECURITY_PASSWORD_SALT': None,
+        'SECURITY_PASSWORD_SINGLE_HASH': True,
     })
     with app.app_context():
         assert verify_password('pass', encrypt_password('pass'))
@@ -24,7 +35,8 @@ def test_verify_password_bcrypt(app, sqlalchemy_datastore):
 def test_login_with_bcrypt_enabled(app, sqlalchemy_datastore):
     init_app_with_options(app, sqlalchemy_datastore, **{
         'SECURITY_PASSWORD_HASH': 'bcrypt',
-        'SECURITY_PASSWORD_SALT': 'salty'
+        'SECURITY_PASSWORD_SALT': 'salty',
+        'SECURITY_PASSWORD_SINGLE_HASH': False,
     })
     response = authenticate(app.test_client(), follow_redirects=True)
     assert b'Home Page' in response.data
@@ -34,4 +46,14 @@ def test_missing_hash_salt_option(app, sqlalchemy_datastore):
     with raises(RuntimeError):
         init_app_with_options(app, sqlalchemy_datastore, **{
             'SECURITY_PASSWORD_HASH': 'bcrypt',
+            'SECURITY_PASSWORD_SINGLE_HASH': False,
+        })
+
+
+def test_single_hash_should_have_no_salt(app, sqlalchemy_datastore):
+    with raises(RuntimeError):
+        init_app_with_options(app, sqlalchemy_datastore, **{
+            'SECURITY_PASSWORD_HASH': 'bcrypt',
+            'SECURITY_PASSWORD_SALT': 'salty',
+            'SECURITY_PASSWORD_SINGLE_HASH': True,
         })


### PR DESCRIPTION
This PR adds a new configuration parameter called SECURITY_SINGLE_HASH which instructs flask-security to skip the step of hashing passwords with SECURITY_PASSWORD_SALT, and instead only use the random salt as provided by passlib.

Use case is integrating more easily with other apps that use passlib.