### PR TITLE
core: use bcrypt by default

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -32,7 +32,7 @@ Core
                                          values for production systems are
                                          ``bcrypt``, ``sha512_crypt``, or
                                          ``pbkdf2_sha512``. Defaults to
-                                         ``plaintext``.
+                                         ``bcrypt``.
 ``SECURITY_PASSWORD_SALT``               Specifies the HMAC salt. This is only
                                          used if the password hash type is set
                                          to something other than plain text.

--- a/docs/features.rst
+++ b/docs/features.rst
@@ -30,12 +30,12 @@ control, you can refer to the Flask-Principal `documentation on this topic`_.
 Password Hashing
 ----------------
 
-Password hashing is enabled with `passlib`_. Passwords are stored in plain
-text by default but you can easily configure the hashing algorithm. You
-should **always use an hashing algorithm** in your production environment.
-You may also specify to use HMAC with a configured salt value in addition to the
-algorithm chosen. Bear in mind passlib does not assume which algorithm you will
-choose and may require additional libraries to be installed.
+Password hashing is enabled with `passlib`_. Passwords are hashed with the
+`bcrypt`_ function by default but you can easily configure the hashing
+algorithm. You should **always use an hashing algorithm** in your production
+environment. You may also specify to use HMAC with a configured salt value in
+addition to the algorithm chosen. Bear in mind passlib does not assume which
+algorithm you will choose and may require additional libraries to be installed.
 
 
 Basic HTTP Authentication
@@ -134,3 +134,4 @@ Run ``flask --help`` and look for users and roles.
 .. _Flask-Principal: http://packages.python.org/Flask-Principal/
 .. _documentation on this topic: http://packages.python.org/Flask-Principal/#granular-resource-protection
 .. _passlib: http://packages.python.org/passlib/
+.. _bcrypt: https://en.wikipedia.org/wiki/Bcrypt

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -42,7 +42,7 @@ _default_config = {
     'URL_PREFIX': None,
     'SUBDOMAIN': None,
     'FLASH_MESSAGES': True,
-    'PASSWORD_HASH': 'plaintext',
+    'PASSWORD_HASH': 'bcrypt',
     'PASSWORD_SALT': None,
     'PASSWORD_SINGLE_HASH': False,
     'LOGIN_URL': '/login',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,8 @@ def app(request):
     app.config['LOGIN_DISABLED'] = False
     app.config['WTF_CSRF_ENABLED'] = False
 
+    app.config['SECURITY_PASSWORD_SALT'] = 'salty'
+
     for opt in ['changeable', 'recoverable', 'registerable',
                 'trackable', 'passwordless', 'confirmable']:
         app.config['SECURITY_' + opt.upper()] = opt in request.keywords

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -46,6 +46,7 @@ def test_missing_hash_salt_option(app, sqlalchemy_datastore):
     with raises(RuntimeError):
         init_app_with_options(app, sqlalchemy_datastore, **{
             'SECURITY_PASSWORD_HASH': 'bcrypt',
+            'SECURITY_PASSWORD_SALT': None,
             'SECURITY_PASSWORD_SINGLE_HASH': False,
         })
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -164,6 +164,8 @@ def test_invalid_hash_scheme(app, sqlalchemy_datastore, get_message):
 
 def test_change_hash_type(app, sqlalchemy_datastore):
     init_app_with_options(app, sqlalchemy_datastore, **{
+        'SECURITY_PASSWORD_HASH': 'plaintext',
+        'SECURITY_PASSWORD_SALT': None,
         'SECURITY_PASSWORD_SCHEMES': ['bcrypt', 'plaintext']
     })
 


### PR DESCRIPTION
Consequence of the discussion in https://github.com/mattupstate/flask-security/issues/545: I strongly agree with @caseydm and @WilliamMayor on the fact that this library should be secure by default. See also https://github.com/mattupstate/flask-security/issues/244.

This is a breaking change, so it should happen in something like `2.1.0` if not `3.0.0`.