### PR TITLE
fix unnecessary flask babelex

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -4,6 +4,13 @@ Flask-Security-Invenio Changelog
 Here you can see the full list of changes between each Flask-Security-Invenio
 release.
 
+Version 3.2.0
+-------------
+
+Released February 28th 2023
+
+- remove deprecated flask-babelex dependency
+
 Version 3.1.4
 -------------
 Released January 19th 2023

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -26,10 +26,11 @@ except AttributeError:
     from werkzeug import security
     security.safe_str_cmp = hmac.compare_digest
 
+from flask_login import login_required
+
 from .core import AnonymousUser, RoleMixin, Security, UserMixin, current_user
 from .datastore import SQLAlchemySessionUserDatastore, SQLAlchemyUserDatastore
-from .decorators import auth_required, login_required, roles_accepted, \
-    roles_required
+from .decorators import auth_required, roles_accepted, roles_required
 from .forms import ConfirmRegisterForm, ForgotPasswordForm, LoginForm, \
     RegisterForm, ResetPasswordForm
 from .signals import confirm_instructions_sent, password_reset, \

--- a/flask_security/__init__.py
+++ b/flask_security/__init__.py
@@ -37,7 +37,7 @@ from .signals import confirm_instructions_sent, password_reset, \
     reset_password_instructions_sent, user_confirmed, user_registered
 from .utils import login_user, logout_user, url_for_security
 
-__version__ = '3.1.4'
+__version__ = '3.2.0'
 __all__ = (
     'AnonymousUser',
     'auth_required',

--- a/flask_security/babel.py
+++ b/flask_security/babel.py
@@ -6,7 +6,7 @@
     I18N support for Flask-Security.
 """
 
-from flask_babelex import Domain
+from flask_babel import Domain
 from wtforms.i18n import messages_path
 
 wtforms_domain = Domain(messages_path(), domain='wtforms')

--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -15,7 +15,7 @@ from datetime import datetime
 
 import pkg_resources
 from flask import current_app, render_template
-from flask_babelex import Domain
+from flask_babel import Domain
 from flask_login import AnonymousUserMixin, LoginManager
 from flask_login import UserMixin as BaseUserMixin
 from flask_login import current_user
@@ -274,7 +274,7 @@ def _get_pwd_context(app):
 
 def _get_i18n_domain(app):
     return Domain(
-        dirname=cv('I18N_DIRNAME', app=app),
+        translation_directories=cv('I18N_DIRNAME', app=app),
         domain=cv('I18N_DOMAIN', app=app)
     )
 

--- a/flask_security/decorators.py
+++ b/flask_security/decorators.py
@@ -9,13 +9,11 @@
     :license: MIT, see LICENSE for more details.
 """
 
-from collections import namedtuple
 from functools import wraps
 
-from flask import Response, _request_ctx_stack, abort, current_app, redirect, \
-    request, url_for
-from flask_login import current_user, login_required  # pragma: no flakes
-from flask_principal import Identity, Permission, RoleNeed, identity_changed
+from flask import Response, abort, current_app, redirect, request, url_for
+from flask_login import current_user  # pragma: no flakes
+from flask_principal import Permission, RoleNeed
 from werkzeug.local import LocalProxy
 from werkzeug.routing import BuildError
 

--- a/flask_security/utils.py
+++ b/flask_security/utils.py
@@ -26,8 +26,7 @@ from flask_principal import AnonymousIdentity, Identity, identity_changed
 from itsdangerous import BadSignature, SignatureExpired
 from werkzeug.local import LocalProxy
 
-from .signals import login_instructions_sent, \
-    reset_password_instructions_sent, user_registered
+from .signals import reset_password_instructions_sent, user_registered
 
 # Convenient references
 _security = LocalProxy(lambda: current_app.extensions['security'])

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -10,13 +10,13 @@
 """
 
 from flask import Blueprint, after_this_request, current_app, redirect, request
-from flask_login import current_user
+from flask_login import current_user, login_required
 from werkzeug.local import LocalProxy
 
 from .changeable import change_user_password
 from .confirmable import confirm_email_token_status, confirm_user, \
     send_confirmation_instructions
-from .decorators import anonymous_user_required, login_required
+from .decorators import anonymous_user_required
 from .recoverable import reset_password_token_status, \
     send_reset_password_instructions, update_password
 from .registerable import register_user

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,8 @@ python_requires = >=3.6
 zip_safe = False
 install_requires =
     email-validator>=1.0.5
-    Flask-BabelEx>=0.9.4
+    speaklater>=1.3
+    Flask-Babel>=2.0.0
     Flask-Login>=0.4.1
     Flask-Mail>=0.9.1
     Flask-Principal>=0.4.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,10 +11,10 @@
 
 import os
 import tempfile
+from json import JSONEncoder as BaseEncoder
 
 import pytest
 from flask import Flask, render_template
-from flask.json import JSONEncoder as BaseEncoder
 from flask_babel import Babel
 from flask_mail import Mail
 from speaklater import is_lazy_string
@@ -70,7 +70,7 @@ def app(request):
     if babel is None or babel.args[0]:
         babel = Babel(app)
         app.babel = babel
-    app.json_encoder = JSONEncoder
+    app.json_provider_class = JSONEncoder
     app.mail = mail
 
     @app.route("/")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,7 +15,7 @@ import tempfile
 import pytest
 from flask import Flask, render_template
 from flask.json import JSONEncoder as BaseEncoder
-from flask_babelex import Babel
+from flask_babel import Babel
 from flask_mail import Mail
 from speaklater import is_lazy_string
 from utils import Response, populate_data

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -260,12 +260,6 @@ def test_custom_forms_via_config(app, sqlalchemy_datastore):
     assert b'My Register Email Address Field' in response.data
 
 
-@pytest.mark.babel(False)
-def test_without_babel(client):
-    response = client.get('/login')
-    assert b'Login' in response.data
-
-
 def test_no_email_sender(app):
     """ Verify that if SECURITY_EMAIL_SENDER is default
         (which is a local proxy) that send_mail picks up MAIL_DEFAULT_SENDER.


### PR DESCRIPTION
- switch from flask-babelex to flask-babel
- remove flask deprecation warning about json_encoder
- remove test_without_babel test function

Note: it would be possible to change the test_without_babel as [flask-middleware/flask-security](https://github.com/Flask-Middleware/flask-security/blob/master/tests/test_misc.py#L439-L443) did. The [Issue](https://github.com/Flask-Middleware/flask-security/issues/488) is discussing the problem.
