### PR TITLE
fix utcnow with custom type

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -12,7 +12,7 @@ Flask-Security core module
 :license: MIT, see LICENSE for more details.
 """
 
-from datetime import datetime
+from datetime import datetime, timezone
 from importlib.resources import files
 
 from flask import current_app, render_template
@@ -125,7 +125,7 @@ _default_config = {
         "hex_md5",
     ],
     "DEPRECATED_HASHING_SCHEMES": ["hex_md5"],
-    "DATETIME_FACTORY": datetime.utcnow,
+    "DATETIME_FACTORY": lambda: datetime.now(timezone.utc).replace(tzinfo=None),
 }
 
 #: Default Flask-Security messages

--- a/flask_security/datastore.py
+++ b/flask_security/datastore.py
@@ -211,7 +211,7 @@ class SQLAlchemyUserDatastore(SQLAlchemyDatastore, UserDatastore):
                 return rv
 
     def get_user_by_id(self, identifier):
-        return self.user_model.query.get(identifier)
+        return self.db.session.get(self.user_model, identifier)
 
     def find_user(self, **kwargs):
         return self.user_model.query.filter_by(**kwargs).first()


### PR DESCRIPTION
- forms: provide validate function compatibility
- release: v3.1.4
- setup: switch from flask-babelex to flask-babel
- fix: remove flask deprecation warning
- fix: remove test_without_babel test function
- code quality: remove unused imports
- babel: fix deprecated import
- release: v3.2.0
- fix: deprecation warning of before_first_request
- decouple get_user -> get_user_by_email + get_user_by_id
- Pin Flask and Werkzeug
- Add get_user with deprecation warning
- tests: reset test to use get_user
- release: v3.3.0
- datastore: fix evaluate user id
- release: v3.3.1
- utils: add support for user impersonation
- release: v3.3.2
- logout: pop impersonator id from session
- release: v3.3.3
- i18n-global: add compile-catalog fuzzy (#57)
- setup: add black
- setup: remove flask upper pin
- test: update test matrix
- fix: LegacyAPIWarning
- tests: move to reusable workflows
- black: add .git-blame-ignore-revs
- release: v3.4.0
- chore: auto format with black
- fix: standardize configuration keys in setup.cfg
- i18n: add Transifex configuration
- i18n: update babel.ini
- chore: include Transifex configuration in MANIFEST.in
- i18n: add workflows for pulling and pushing
- i18n: update translations template for Flask-Security-Invenio
- chore: remove obsolete release script
- update copyrights
- chore: ignore auto format
- i18n:pulled translations (#68)
- 📦 release: v3.5.0
- i18n:pulled translations
- 📦 release: v3.5.1
- fix: pkg_resources DeprecationWarning
- release: v3.6.0
- i18n:push translations
- i18n:pulled translations
- release: v3.7.0
- fix: utcnow deprecation warning
- fix: sqlalchemy Query.get deprecation warning
