### PR TITLE
Fix - don't allow re-use of confirmation token.

### DIFF
--- a/flask_security/core.py
+++ b/flask_security/core.py
@@ -97,6 +97,7 @@ _default_config = {
     "CONFIRM_EMAIL_WITHIN": "5 days",
     "RESET_PASSWORD_WITHIN": "5 days",
     "LOGIN_WITHOUT_CONFIRMATION": False,
+    "AUTO_LOGIN_AFTER_CONFIRM": True,
     "EMAIL_SENDER": LocalProxy(
         lambda: current_app.config.get("MAIL_DEFAULT_SENDER", "no-reply@localhost")
     ),

--- a/flask_security/views.py
+++ b/flask_security/views.py
@@ -141,39 +141,50 @@ def confirm_email(token):
     expired, invalid, user = confirm_email_token_status(token)
 
     if not user or invalid:
-        invalid = True
         do_flash(*get_message("INVALID_CONFIRMATION_TOKEN"))
-
-    already_confirmed = user is not None and user.confirmed_at is not None
-
-    if expired and not already_confirmed:
-        send_confirmation_instructions(user)
-        do_flash(
-            *get_message(
-                "CONFIRMATION_EXPIRED",
-                email=user.email,
-                within=_security.confirm_email_within,
-            )
+        return redirect(
+            get_url(_security.confirm_error_view) or url_for("send_confirmation")
         )
-    if invalid or (expired and not already_confirmed):
+
+    already_confirmed = user.confirmed_at is not None
+
+    if expired or already_confirmed:
+        if already_confirmed:
+            do_flash(*get_message("ALREADY_CONFIRMED"))
+        else:
+            send_confirmation_instructions(user)
+            do_flash(
+                *get_message(
+                    "CONFIRMATION_EXPIRED",
+                    email=user.email,
+                    within=_security.confirm_email_within,
+                )
+            )
         return redirect(
             get_url(_security.confirm_error_view) or url_for("send_confirmation")
         )
 
     if user != current_user:
         logout_user()
-        login_user(user)
+        if config_value("AUTO_LOGIN_AFTER_CONFIRM"):
+            # N.B. this is a (small) security risk if email went to wrong place.
+            # and you have the LOGIN_WITHOUT_CONFIRMATION flag since in that case
+            # you can be logged in and doing stuff - but another person could
+            # get the email.
+            login_user(user)
 
-    if confirm_user(user):
-        after_this_request(_commit)
-        msg = "EMAIL_CONFIRMED"
-    else:
-        msg = "ALREADY_CONFIRMED"
+    confirm_user(user)
+    after_this_request(_commit)
 
-    do_flash(*get_message(msg))
+    do_flash(*get_message("EMAIL_CONFIRMED"))
 
     return redirect(
-        get_url(_security.post_confirm_view) or get_url(_security.post_login_view)
+        get_url(_security.post_confirm_view)
+        or get_url(
+            _security.post_login_view
+            if config_value("AUTO_LOGIN_AFTER_CONFIRM")
+            else _security.login_url
+        )
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,6 +111,10 @@ def app(request):
     def post_register():
         return render_template("index.html", content="Post Register")
 
+    @app.route("/post_confirm")
+    def post_confirm():
+        return render_template("index.html", content="Post Confirm")
+
     @app.route("/admin")
     @roles_required("admin")
     def admin():

--- a/tests/test_confirmable.py
+++ b/tests/test_confirmable.py
@@ -157,6 +157,88 @@ def test_login_when_unconfirmed(client, get_message):
 
 
 @pytest.mark.registerable()
+def test_confirmation_token_reuse_does_not_auto_login(client, get_message):
+    """A reused confirmation link must not silently log the user in."""
+    email = "reuse@lp.com"
+
+    with capture_registrations() as registrations:
+        data = dict(email=email, password="password", next="")
+        client.post("/register", data=data)
+
+    token = registrations[0]["confirm_token"]
+
+    # First confirm: legitimate, user gets logged in (default AUTO_LOGIN_AFTER_CONFIRM=True).
+    response = client.get("/confirm/" + token, follow_redirects=True)
+    assert get_message("EMAIL_CONFIRMED") in response.data
+    assert b"Hello " + email.encode() in response.data
+
+    logout(client)
+
+    # Re-using the same link from anonymous context must NOT log us back in.
+    response = client.get("/confirm/" + token, follow_redirects=True)
+    assert get_message("ALREADY_CONFIRMED") in response.data
+    assert b"Hello " + email.encode() not in response.data
+
+
+@pytest.mark.registerable()
+@pytest.mark.settings(login_without_confirmation=True, auto_login_after_confirm=False)
+def test_confirmation_different_user_when_logged_in_no_auto(client, get_message):
+    """AUTO_LOGIN_AFTER_CONFIRM=False must not log the second user in."""
+    e1 = "dude@lp.com"
+    e2 = "lady@lp.com"
+
+    with capture_registrations() as registrations:
+        for e in e1, e2:
+            data = dict(email=e, password="password", next="")
+            client.post("/register", data=data)
+            logout(client)
+
+    token1 = registrations[0]["confirm_token"]
+    token2 = registrations[1]["confirm_token"]
+
+    client.get("/confirm/" + token1, follow_redirects=True)
+    logout(client)
+    authenticate(client, email=e1)
+
+    response = client.get("/confirm/" + token2, follow_redirects=True)
+    assert get_message("EMAIL_CONFIRMED") in response.data
+    # second user must not have been logged in
+    assert b"Hello " + e2.encode() not in response.data
+
+
+@pytest.mark.registerable()
+@pytest.mark.settings(auto_login_after_confirm=False)
+def test_confirm_redirect(client, get_message):
+    """With AUTO_LOGIN_AFTER_CONFIRM=False, redirect target is the login URL."""
+    with capture_registrations() as registrations:
+        data = dict(email="jane@lp.com", password="password", next="")
+        client.post("/register", data=data, follow_redirects=True)
+
+    token = registrations[0]["confirm_token"]
+
+    response = client.get("/confirm/" + token)
+    assert "location" in response.headers
+    assert "/login" in response.location
+
+    response = client.get(response.location)
+    assert get_message("EMAIL_CONFIRMED") in response.data
+
+
+@pytest.mark.registerable()
+@pytest.mark.settings(post_confirm_view="/post_confirm")
+def test_confirm_redirect_to_post_confirm(client, get_message):
+    """post_confirm_view takes precedence over the login redirect."""
+    with capture_registrations() as registrations:
+        data = dict(email="john@lp.com", password="password", next="")
+        client.post("/register", data=data, follow_redirects=True)
+
+    token = registrations[0]["confirm_token"]
+
+    response = client.get("/confirm/" + token, follow_redirects=True)
+    assert b"Post Confirm" in response.data
+
+
+@pytest.mark.registerable()
 @pytest.mark.settings(login_without_confirmation=True)
 def test_confirmation_different_user_when_logged_in(client, get_message):
     e1 = "dude@lp.com"


### PR DESCRIPTION
Added option to not automatically log in user when they confirm their registration.
The default still it to log in the user.

Backport of pallets-eco/flask-security#137.

Co-authored-by: Alex Ioannidis <a.ioannidis@cern.ch>
